### PR TITLE
docs: add "testing preset" to `01-writing-a-preset.md`

### DIFF
--- a/content/docs/03-guides/01-writing-a-preset.md
+++ b/content/docs/03-guides/01-writing-a-preset.md
@@ -37,6 +37,12 @@ Preset.extract('default');
 Preset.extract('auth').ifHasOption('auth');
 ```
 
+## Testing the preset locally
+
+```shell
+npx apply /path/to/your/preset
+```
+
 ## Tip: archiving edited files
 
 When creating a preset from a test project, if you committed its initial state and started editing it, you can use `git diff` to list the modified files.


### PR DESCRIPTION
I think this section is missing (personally I was looking for it before reading the "Getting started -> usage" section)